### PR TITLE
Option to vary ploidy

### DIFF
--- a/compkaryo/compkaryo.py
+++ b/compkaryo/compkaryo.py
@@ -9,22 +9,42 @@ Created on Tue May 15 16:57:04 2018
 import argparse
 import pkgutil
 import sys
-
 import numpy as np
-
 import allel
 
-##read in the predictive SNPs for the inversion of interest
 
-##extract the predictive SNPs from the supplied callset
+def get_numbers_dict(ploidy):
+    numbers = {
+        'samples':1,
+        'variants/CHROM': 1,
+        'variants/POS': 1,
+        'variants/ID': 1,
+        'variants/REF': 1,
+        'variants/ALT': 'A',
+        'variants/QUAL': 1,
+        'variants/DP': 1,
+        'variants/AN': 1,
+        'variants/AC': 'A',
+        'variants/AF': 'A',
+        'variants/MQ': 1,
+        'variants/ANN': 1,
+        'calldata/DP': 1,
+        'calldata/GT': ploidy,
+        'calldata/GQ': 1,
+        'calldata/HQ': 2,
+        'calldata/AD': 'R',
+        'calldata/MQ0': 1,
+        'calldata/MQ': 1,
+        }
+    return(numbers)
 
-##calculate the average genotype across the predictive SNPs
 
-##return the average genotype and the # of sites across which it was calculated
-
-##please note: you can modify this software to work in other systems
-
-##or with other SNPs by changing inversionDict
+## read in the predictive SNPs for the inversion of interest
+## extract the predictive SNPs from the supplied callset
+## calculate the average genotype across the predictive SNPs
+## return the average genotype and the # of sites across which it was calculated
+## please note: you can modify this software to work in other systems
+## or with other SNPs by changing inversionDict
 
 inversionDict = {"2La" : ("2L", "targets/2La_targets.txt"),
                  "2Rj" : ("2R", "targets/2Rj_targets.txt"),
@@ -54,6 +74,7 @@ def parse_args(custom_args=None):
     parser.add_argument("-t", "--totals",
                         help="total # sites supporting each genotype",
                         action='store_true')
+    parser.add_argument("-p", "--ploidy", help="Ploidy level in VCF", default=2)
 
     args = parser.parse_args(custom_args)
 
@@ -63,7 +84,10 @@ def import_data(callset_path):
 
     '''Read in the VCF in the appropriate format.'''
 
+    numbers = get_numbers_dict(args.ploidy)
+
     callset = allel.read_vcf(callset_path,
+                             numbers=numbers,
                              fields=['samples', 'calldata/GT',
                                      'variants/CHROM', 'variants/FILTER',
                                      'variants/POS', 'variants/REF',

--- a/compkaryo/compkaryo.py
+++ b/compkaryo/compkaryo.py
@@ -9,42 +9,23 @@ Created on Tue May 15 16:57:04 2018
 import argparse
 import pkgutil
 import sys
+
 import numpy as np
 import allel
 
 
-def get_numbers_dict(ploidy):
-    numbers = {
-        'samples':1,
-        'variants/CHROM': 1,
-        'variants/POS': 1,
-        'variants/ID': 1,
-        'variants/REF': 1,
-        'variants/ALT': 'A',
-        'variants/QUAL': 1,
-        'variants/DP': 1,
-        'variants/AN': 1,
-        'variants/AC': 'A',
-        'variants/AF': 'A',
-        'variants/MQ': 1,
-        'variants/ANN': 1,
-        'calldata/DP': 1,
-        'calldata/GT': ploidy,
-        'calldata/GQ': 1,
-        'calldata/HQ': 2,
-        'calldata/AD': 'R',
-        'calldata/MQ0': 1,
-        'calldata/MQ': 1,
-        }
-    return(numbers)
-
-
 ## read in the predictive SNPs for the inversion of interest
+
 ## extract the predictive SNPs from the supplied callset
+
 ## calculate the average genotype across the predictive SNPs
+
 ## return the average genotype and the # of sites across which it was calculated
+
 ## please note: you can modify this software to work in other systems
+
 ## or with other SNPs by changing inversionDict
+
 
 inversionDict = {"2La" : ("2L", "targets/2La_targets.txt"),
                  "2Rj" : ("2R", "targets/2Rj_targets.txt"),
@@ -79,6 +60,37 @@ def parse_args(custom_args=None):
     args = parser.parse_args(custom_args)
 
     return args
+
+def get_numbers_dict(ploidy):
+
+    """ 
+    Initialise dict for sci-kit allel.read_vcf() 
+    Allows for variable ploidy in vcf (useful for pool/RNA-Seq)
+    """
+    numbers = {
+        'samples':1,
+        'variants/CHROM': 1,
+        'variants/POS': 1,
+        'variants/ID': 1,
+        'variants/REF': 1,
+        'variants/ALT': 'A',
+        'variants/QUAL': 1,
+        'variants/DP': 1,
+        'variants/AN': 1,
+        'variants/AC': 'A',
+        'variants/AF': 'A',
+        'variants/MQ': 1,
+        'variants/ANN': 1,
+        'calldata/DP': 1,
+        'calldata/GT': ploidy,
+        'calldata/GQ': 1,
+        'calldata/HQ': 2,
+        'calldata/AD': 'R',
+        'calldata/MQ0': 1,
+        'calldata/MQ': 1,
+        }
+        
+    return numbers
 
 def import_data(callset_path):
 


### PR DESCRIPTION
Hi Becca (Nice to meet you!), 

I wanted to use compkaryo on some RNA-Sequencing data - Im developing a pipeline which has some Anopheles specific modules (https://github.com/sanjaynagi/rna-seq-ir). These samples are (usually) pooled, and so we called variants at a ploidy level of n_individuals*2. 

I've modified the compkaryo script (very slightly), adding an option to vary the ploidy level thats found in the vcf file.  

I dont know if its something you'd want to include, in case it is, here is a PR. 
Cheers
